### PR TITLE
gen: fix tx generation, int fails to be emitted

### DIFF
--- a/cmd/internal/gen.go
+++ b/cmd/internal/gen.go
@@ -43,7 +43,7 @@ func newTX(wif *keys.WIF) *transaction.Transaction {
 	w := io.NewBufBinWriter()
 	emit.AppCallWithOperationAndArgs(w.BinWriter,
 		client.NeoContractHash, "transfer",
-		fromAddressHash, fromAddressHash, 1)
+		fromAddressHash, fromAddressHash, int64(1))
 	emit.Opcode(w.BinWriter, opcode.ASSERT)
 
 	script := w.Bytes()


### PR DESCRIPTION
emit.AppCallWithOperationAndArgs creates an array of arguments for invocation
with Array function that doesn't really support ints, though works fine with
int64.