### PR TITLE
worker: poll for blocks more often

### DIFF
--- a/cmd/internal/worker.go
+++ b/cmd/internal/worker.go
@@ -265,7 +265,7 @@ func (d *doer) Parser(ctx context.Context, blk *block.Block) {
 	defer close(d.parsed)
 
 	done := ctx.Done()
-	period := 5 * time.Second
+	period := time.Second
 	ticker := time.NewTimer(period)
 	timeout := time.NewTimer(d.timeLimit + 5*time.Minute)
 	lastBlockIndx := int(blk.Index)


### PR DESCRIPTION
We shouldn't affect testing as much as we can by this polling, so ideally we
would just not do it at all while pushing transactions and do statistics
collection at least after all transactions have been sent. But we also want to
have some live view of the things going on to quickly detect misbehavior and
to get some initial results sooner.

So when we're testing single node it is set up to produce one block per
second, it usually can't do that while been stressed, but it at the same time
usually manages to push a block in 2-3 seconds, so when we're polling for new
blocks once per 5 seconds we may occasionaly find out that there were some 2-3
blocks already made. The poller would then fetch these blocks and that's where
the problem occurs because it's very easy to get the top block (costs almost
nothing to do that, just needs some serialization), but it is quite expensive
to get older blocks as it requires making many requests to the DB which
seriously affects testing.

So in the end it's better for us to poll more often (getting block count is
just an atomic uint32 read, cheapo), but always get the top block in
subsequent `getblock` request.

Makes our results at least some 2-3%% better.