### PR TITLE
cmd: be carefull with counting zero TPS values

### DIFF
--- a/cmd/internal/report.go
+++ b/cmd/internal/report.go
@@ -18,6 +18,7 @@ type (
 		ErrCount int32
 		RPS      []float64
 		TPS      []float64
+		TPSPool  []float64
 		Stats    [][2]float64 // CPU, Mem
 	}
 
@@ -233,7 +234,13 @@ func (r *reporter) UpdateTPS(v float64) {
 	r.Lock()
 	defer r.Unlock()
 
-	r.TPS = append(r.TPS, v)
+	if v > 0 {
+		r.TPS = append(r.TPS, r.TPSPool...)
+		r.TPS = append(r.TPS, v)
+		r.TPSPool = nil
+	} else {
+		r.TPSPool = append(r.TPSPool, v)
+	}
 }
 
 // UpdateRes sets current resource usage by containers.

--- a/cmd/internal/worker.go
+++ b/cmd/internal/worker.go
@@ -357,7 +357,7 @@ func (d *doer) parse(ctx context.Context, startBlock int, lastTime *uint64) (las
 			// report current tps
 			d.tpsReporter(tps)
 
-			for i := 1; i < cnt; i++ {
+			for i := 0; i < cnt; i++ {
 				tx := blk.Transactions[i]
 				if len(tx.Scripts) > 0 {
 					if _, ok := d.dump.Hashes[tx.Hash().String()]; ok {


### PR DESCRIPTION
1. Refactor some old 2-x code.
2. Do not pay attention to zero TPS values at the start and at the end of the test.