### PR TITLE
*: logging improvements

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -115,9 +115,10 @@ func main() {
 		log.Fatalf("could not create docker stats grabber: %v", err)
 	}
 
+	statsStart := time.Now()
 	// Run stats worker:
 	go ds.Run(ctx, func(cpu, mem float64) {
-		rep.UpdateRes(cpu, mem)
+		rep.UpdateRes(statsStart, cpu, mem)
 		log.Printf("CPU: %0.3f%%, Mem: %0.3fMB", cpu, mem)
 	})
 

--- a/cmd/internal/report.go
+++ b/cmd/internal/report.go
@@ -17,9 +17,18 @@ type (
 		TxCount  int32
 		ErrCount int32
 		RPS      []float64
-		TPS      []float64
-		TPSPool  []float64
+		TPS      []tpsInfo
+		TPSPool  []tpsInfo
 		Stats    [][3]float64 // MillisecondsFromStart, CPU, Mem
+	}
+
+	// tpsInfo stores information useful for counting TPS
+	tpsInfo struct {
+		// DeltaTime is a time in milliseconds since the previous block timestamp
+		DeltaTime uint64
+		// TxCount is the number of transactions in block
+		TxCount int
+		TPS     float64
 	}
 
 	// Reporter interface.
@@ -28,7 +37,7 @@ type (
 		UpdateErr(v int32)
 		UpdateCnt(v int32)
 		UpdateRPS(v float64)
-		UpdateTPS(v float64)
+		UpdateTPS(deltaTime uint64, txCount int, v float64)
 		UpdateRes(start time.Time, cpu, mem float64)
 	}
 
@@ -119,7 +128,7 @@ func (r *reporter) WriteTo(rw io.Writer) (int64, error) {
 
 	tps := .0
 	for i := range r.TPS {
-		tps += r.TPS[i]
+		tps += r.TPS[i].TPS
 	}
 
 	cpu := .0
@@ -189,13 +198,13 @@ func (r *reporter) WriteTo(rw io.Writer) (int64, error) {
 		cnt += int64(num)
 	}
 
-	if num, err = fmt.Fprintln(out, "\nTPS"); err != nil {
+	if num, err = fmt.Fprintln(out, "\nDeltaTime, TransactionsCount, TPS"); err != nil {
 		return cnt + int64(num), err
 	}
 	cnt += int64(num)
 
 	for i := range r.TPS {
-		if num, err = fmt.Fprintf(out, "%0.3f\n", r.TPS[i]); err != nil {
+		if num, err = fmt.Fprintf(out, "%d, %d, %0.3f\n", r.TPS[i].DeltaTime, r.TPS[i].TxCount, r.TPS[i].TPS); err != nil {
 			return cnt + int64(num), err
 		}
 		cnt += int64(num)
@@ -241,7 +250,7 @@ func (r *reporter) UpdateErr(v int32) {
 }
 
 // UpdateTPS sets current tps rate
-func (r *reporter) UpdateTPS(v float64) {
+func (r *reporter) UpdateTPS(deltaTime uint64, txCount int, v float64) {
 	if v < 0 || math.IsNaN(v) {
 		return
 	}
@@ -251,10 +260,18 @@ func (r *reporter) UpdateTPS(v float64) {
 
 	if v > 0 {
 		r.TPS = append(r.TPS, r.TPSPool...)
-		r.TPS = append(r.TPS, v)
+		r.TPS = append(r.TPS, tpsInfo{
+			DeltaTime: deltaTime,
+			TxCount:   txCount,
+			TPS:       v,
+		})
 		r.TPSPool = nil
 	} else {
-		r.TPSPool = append(r.TPSPool, v)
+		r.TPSPool = append(r.TPSPool, tpsInfo{
+			DeltaTime: deltaTime,
+			TxCount:   txCount,
+			TPS:       v,
+		})
 	}
 }
 

--- a/cmd/internal/worker.go
+++ b/cmd/internal/worker.go
@@ -45,7 +45,7 @@ type (
 		cntReporter func(cnt int32)
 		errReporter func(cnt int32)
 		rpsReporter func(rps float64)
-		tpsReporter func(tps float64)
+		tpsReporter func(deltaTime uint64, txCount int, tps float64)
 		stop        context.CancelFunc
 	}
 
@@ -122,7 +122,7 @@ func WorkerRPSReporter(reporter func(v float64)) WorkerOption {
 }
 
 // WorkerTPSReporter sets method that would be used to report current TPS.
-func WorkerTPSReporter(reporter func(v float64)) WorkerOption {
+func WorkerTPSReporter(reporter func(deltaTime uint64, txCount int, v float64)) WorkerOption {
 	return func(p *doerParams) {
 		// ignore empty func
 		if reporter == nil {
@@ -164,7 +164,7 @@ func NewWorkers(opts ...WorkerOption) (Worker, error) {
 		cntReporter: func(_ int32) {},
 		errReporter: func(_ int32) {},
 		rpsReporter: func(_ float64) {},
-		tpsReporter: func(_ float64) {},
+		tpsReporter: func(_ uint64, _ int, _ float64) {},
 		stop:        func() { log.Fatal("default stopper") },
 	}
 
@@ -377,7 +377,7 @@ func (d *doer) parse(ctx context.Context, startBlock int, lastTime *uint64) (las
 			}
 
 			// report current tps
-			d.tpsReporter(tps)
+			d.tpsReporter(dt, len(blk.Transactions), tps)
 
 			for i := 0; i < cnt; i++ {
 				tx := blk.Transactions[i]

--- a/cmd/internal/worker.go
+++ b/cmd/internal/worker.go
@@ -362,7 +362,7 @@ func (d *doer) parse(ctx context.Context, startBlock int, lastTime *uint64) (las
 
 			// Timestamp is in milliseconds so we multiply numerator by 1000 to be more precise.
 			dt := blk.Timestamp - *lastTime
-			if tps = float64(cnt-1) * 1000 / float64(dt); math.IsNaN(tps) || tps < 0 {
+			if tps = float64(cnt) * 1000 / float64(dt); math.IsNaN(tps) || tps < 0 {
 				tps = 0
 			}
 

--- a/plot.py
+++ b/plot.py
@@ -95,7 +95,7 @@ def plot_data(path):
                         tpsStart = i + 2
                         break
                 for i in range(tpsStart, len(lines)):
-                    tpsFile.append(float(lines[i]))
+                    tpsFile.append(float(lines[i].split(', ')[2]))
             tps[fileCounter] = tpsFile
             cpu[fileCounter] = cpuFile
             mem[fileCounter] = memFile

--- a/plot.py
+++ b/plot.py
@@ -68,6 +68,7 @@ def plot_data(path):
 
     for name, files in files_batch.items():
         tps = [[]]*len(files)
+        secondsFromStart = [[]]*len(files)
         cpu = [[]]*len(files)
         mem = [[]]*len(files)
         avgTps = []*len(files)
@@ -75,6 +76,7 @@ def plot_data(path):
         # extract data
         for fileCounter in range(len(files)):
             file = files[fileCounter]
+            secondsFromStartFile = []
             cpuFile = []
             memFile = []
             tpsFile = []
@@ -85,7 +87,9 @@ def plot_data(path):
                     line = lines[i]
                     cpumem = line.split('%,')
                     if len(cpumem) == 2:
-                        cpuFile.append(float(cpumem[0]))
+                        millisecondsFromStartcpu = cpumem[0].split(', ')
+                        secondsFromStartFile.append(float(millisecondsFromStartcpu[0])/1000)
+                        cpuFile.append(float(millisecondsFromStartcpu[1]))
                         memFile.append(float(cpumem[1].strip(' ').strip('\n').strip('MB')))
                     else:
                         tpsStart = i + 2
@@ -95,6 +99,7 @@ def plot_data(path):
             tps[fileCounter] = tpsFile
             cpu[fileCounter] = cpuFile
             mem[fileCounter] = memFile
+            secondsFromStart[fileCounter] = secondsFromStartFile
 
         # plot tps for `name`
         for i in range(len(files)):
@@ -113,8 +118,8 @@ def plot_data(path):
         # plot cpu for `name`
         for i in range(len(files)):
             file = files[i]
-            plt.plot(cpu[i], label=file[1], color=file[2], linewidth=0.8)
-        plt.xlabel('Time')
+            plt.plot(secondsFromStart[i], cpu[i], label=file[1], color=file[2], linewidth=0.8)
+        plt.xlabel('Time, seconds')
         plt.ylabel('CPU, %')
         plt.title('cpu '+name)
         plt.legend()
@@ -126,8 +131,8 @@ def plot_data(path):
         # plot memory for `name`
         for i in range(len(files)):
             file = files[i]
-            plt.plot(mem[i], label=file[1], color=file[2], linewidth=0.8)
-        plt.xlabel('Time')
+            plt.plot(secondsFromStart[i], mem[i], label=file[1], color=file[2], linewidth=0.8)
+        plt.xlabel('Time, seconds')
         plt.ylabel('Memory, Mb')
         plt.title('memory '+name)
         plt.legend()


### PR DESCRIPTION
1. Save to log the time-from-start for CPU and Memory
2. Save to log the time-between-blocks and txs count for TPS