### PR TITLE
build: specify golang version of base layer explicitly

### DIFF
--- a/.docker/build/Dockerfile.bench
+++ b/.docker/build/Dockerfile.bench
@@ -1,5 +1,5 @@
 # Builder layer
-FROM golang:1-alpine as builder
+FROM golang:1.14-alpine as builder
 
 WORKDIR /bench
 

--- a/.docker/build/Dockerfile.golang
+++ b/.docker/build/Dockerfile.golang
@@ -1,5 +1,5 @@
 # Builder layer
-FROM golang:1-alpine as builder
+FROM golang:1.14-alpine as builder
 
 WORKDIR /neo-go
 


### PR DESCRIPTION
It's important to set the version of Builder layer explicitly. At
the current moment Go 1.15 gives us 22% decline on single-node consensus
test comparing with Go 1.14, so let it be 1.14 for now.