### PR TITLE
config: explicitly set MaxGasInvoe RPC configuration to -1

### DIFF
--- a/.docker/ir/go.protocol.template.yml
+++ b/.docker/ir/go.protocol.template.yml
@@ -62,6 +62,7 @@ ApplicationConfiguration:
     Enabled: true
     EnableCORSWorkaround: false
     Port: #@ data.values.nodes_info[i].node_rpc_port
+    MaxGasInvoke: 50
   Monitoring:
     Enabled: false
     Port: #@ data.values.nodes_info[i].node_monitoring_port


### PR DESCRIPTION
We should be able to use bench environment for manual tests, so let's
not limit MaxGasInvoke, otherwise it's impossible to use
`invokefunction` RPC call.