### PR TITLE
compose: disable logging for all nodes

### DIFF
--- a/.docker/ir/docker-compose.go.yml
+++ b/.docker/ir/docker-compose.go.yml
@@ -14,6 +14,8 @@ services:
       - stats
     container_name: neo_go_node_one
     image: registry.nspcc.ru/neo-bench/neo-go:bench
+    logging:
+      driver: "none"
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s
@@ -31,6 +33,8 @@ services:
       - stats
     container_name: neo_go_node_two
     image: registry.nspcc.ru/neo-bench/neo-go:bench
+    logging:
+      driver: "none"
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s
@@ -48,6 +52,8 @@ services:
       - stats
     container_name: neo_go_node_three
     image: registry.nspcc.ru/neo-bench/neo-go:bench
+    logging:
+      driver: "none"
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s
@@ -65,6 +71,8 @@ services:
       - stats
     container_name: neo_go_node_four
     image: registry.nspcc.ru/neo-bench/neo-go:bench
+    logging:
+      driver: "none"
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s

--- a/.docker/ir/docker-compose.sharp.yml
+++ b/.docker/ir/docker-compose.sharp.yml
@@ -5,6 +5,8 @@ services:
     labels:
       - stats
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
+    logging:
+      driver: "none"
     container_name: neo-cli-node-one
     command: --rpc
     volumes:
@@ -27,6 +29,8 @@ services:
     labels:
       - stats
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
+    logging:
+      driver: "none"
     container_name: neo-cli-node-two
     command: --rpc
     volumes:
@@ -49,6 +53,8 @@ services:
     labels:
       - stats
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
+    logging:
+      driver: "none"
     container_name: neo-cli-node-three
     command: --rpc
     volumes:
@@ -71,6 +77,8 @@ services:
     labels:
       - stats
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
+    logging:
+      driver: "none"
     container_name: neo-cli-node-four
     command: --rpc
     volumes:

--- a/.docker/ir/docker-compose.single.go.yml
+++ b/.docker/ir/docker-compose.single.go.yml
@@ -5,6 +5,8 @@ services:
     labels:
       - stats
     image: registry.nspcc.ru/neo-bench/neo-go:bench
+    logging:
+      driver: "none"
     command: "node --config-path /config --privnet"
     ports: [ "20331:20331" ]
     healthcheck:

--- a/.docker/ir/docker-compose.single.sharp.yml
+++ b/.docker/ir/docker-compose.single.sharp.yml
@@ -5,6 +5,8 @@ services:
     labels:
       - stats
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
+    logging:
+      driver: "none"
     command: --rpc
     ports: [ "20331:20331" ]
     environment:

--- a/.docker/rpc/docker-compose.go.yml
+++ b/.docker/rpc/docker-compose.go.yml
@@ -5,6 +5,8 @@ services:
     labels:
       - stats
     image: registry.nspcc.ru/neo-bench/neo-go:bench
+    logging:
+      driver: "none"
     container_name: go-node
     command: "node --config-path /config --privnet"
     ports: [ "20331:20331" ]

--- a/.docker/rpc/docker-compose.sharp.yml
+++ b/.docker/rpc/docker-compose.sharp.yml
@@ -5,6 +5,8 @@ services:
     labels:
       - stats
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
+    logging:
+      driver: "none"
     container_name: sharp-node
     command: --rpc
     depends_on: [ "healthy" ]


### PR DESCRIPTION
Go nodes can stall on logging:

1 @ 0x482245 0x4800ea 0x49afa9 0x49af34 0x4a1b87 0x4a1b57 0x959f5c 0x94d046 0x94e997 0x968b7f 0xaee3de 0xaf10ad 0x9495b5 0xaeea15 0xae38b7 0x781894 0x784c23 0x78068c 0x467781
	0x482244	syscall.Syscall+0x4									syscall/asm_linux_amd64.s:18
	0x4800e9	syscall.write+0x59									syscall/zsyscall_linux_amd64.go:914
	0x49afa8	syscall.Write+0x178									syscall/syscall_unix.go:214
	0x49af33	internal/poll.(*FD).Write+0x103								internal/poll/fd_unix.go:268
	0x4a1b86	os.(*File).write+0x76									os/file_unix.go:280
	0x4a1b56	os.(*File).Write+0x46									os/file.go:153
	0x959f5b	go.uber.org/zap/zapcore.(*lockedWriteSyncer).Write+0x6b					go.uber.org/zap@v1.10.0/zapcore/write_syncer.go:66
	0x94d045	go.uber.org/zap/zapcore.(*ioCore).Write+0x105						go.uber.org/zap@v1.10.0/zapcore/core.go:90
	0x94e996	go.uber.org/zap/zapcore.(*CheckedEntry).Write+0x116					go.uber.org/zap@v1.10.0/zapcore/entry.go:215
	0x968b7e	go.uber.org/zap.(*Logger).Error+0x7e							go.uber.org/zap@v1.10.0/logger.go:203
	0xaee3dd	github.com/nspcc-dev/neo-go/pkg/rpc/server.(*Server).logRequestError+0x20d		github.com/nspcc-dev/neo-go/pkg/rpc/server/server.go:1493
	0xaf10ac	github.com/nspcc-dev/neo-go/pkg/rpc/server.(*Server).writeHTTPServerResponse.func1+0x3c	github.com/nspcc-dev/neo-go/pkg/rpc/server/server.go:1505
...

1 @ 0x4376a0 0x4485c0 0x4485ab 0x448327 0x47350c 0x959fd8 0x959f12 0x94d046 0x94e997 0x968a5f 0xab58fd 0xab2778 0xab1b25 0xabd6a8 0xab6421 0xac394d 0x467781
	0x448326	sync.runtime_SemacquireMutex+0x46					runtime/sema.go:71
	0x47350b	sync.(*Mutex).lockSlow+0xfb						sync/mutex.go:138
	0x959fd7	sync.(*Mutex).Lock+0xe7							sync/mutex.go:81
	0x959f11	go.uber.org/zap/zapcore.(*lockedWriteSyncer).Write+0x21			go.uber.org/zap@v1.10.0/zapcore/write_syncer.go:65
	0x94d045	go.uber.org/zap/zapcore.(*ioCore).Write+0x105				go.uber.org/zap@v1.10.0/zapcore/core.go:90
	0x94e996	go.uber.org/zap/zapcore.(*CheckedEntry).Write+0x116			go.uber.org/zap@v1.10.0/zapcore/entry.go:215
	0x968a5e	go.uber.org/zap.(*Logger).Info+0x7e					go.uber.org/zap@v1.10.0/logger.go:187
	0xab58fc	github.com/nspcc-dev/dbft.(*DBFT).InitializeConsensus+0x45c		github.com/nspcc-dev/dbft@v0.0.0-20201109143252-cd27d76617ed/dbft.go:105
	0xab2777	github.com/nspcc-dev/dbft.(*DBFT).checkCommit+0x987			github.com/nspcc-dev/dbft@v0.0.0-20201109143252-cd27d76617ed/check.go:75

But we're benchmarking here, so sending logs to /dev/null is fine. If they're
needed to debug something one can turn them on again.