### PR TITLE
*: fix average TPS reporter

### DIFF
--- a/cmd/internal/worker.go
+++ b/cmd/internal/worker.go
@@ -334,13 +334,6 @@ func (d *doer) parse(ctx context.Context, startBlock int, lastTime *uint64) (las
 		return
 	}
 
-	ln := d.countTxs.Load() - int32(lastBlock-startBlock)
-	if ln < 0 {
-		ln = 0
-	}
-
-	// log.Printf("%d txs left to parse", ln)
-
 	for i := startBlock; i < lastBlock; i++ {
 		parsedCount = 0
 


### PR DESCRIPTION
Close #53.
We need to count average TPS value as accepted txs count devided by
overall accepted blocks time.

NOTE: In case of early interrupt TPS value can still be more than RPS
value, because we take into account only those transactions which are
already in chain and do not pay attention to the mempooled ones.