### PR TITLE
*: update C# to preview4

### DIFF
--- a/.docker/build/Dockerfile.sharp
+++ b/.docker/build/Dockerfile.sharp
@@ -18,7 +18,7 @@ RUN wget -O /tmp/neo-modules.zip https://github.com/neo-project/neo-modules/arch
 FROM microsoft/dotnet:3.0-runtime-stretch-slim
 
 # arguments to choose version of neo-cli to install (defaults to 2.10.3)
-ARG VERSION="3.0.0-preview3"
+ARG VERSION="3.0.0-preview4"
 
 # Frontend non-interactive
 ENV DEBIAN_FRONTEND noninteractive
@@ -49,14 +49,15 @@ RUN set -x \
 # $VERSION is a build argument
 ENV URL="https://github.com/neo-project/neo-node/releases/download/v${VERSION}/neo-cli-linux-x64.zip"
 RUN wget -O /opt/neo-cli.zip ${URL} && \
-    unzip -q -d /neo-cli /opt/neo-cli.zip && \
-    mv /neo-cli/linux-x64/* /neo-cli && \
-    rm -r /neo-cli/linux-x64 && \
+    unzip -q -d /tmp /opt/neo-cli.zip && \
+    mkdir /neo-cli && \
+    mv /tmp/neo-cli/* /neo-cli && \
+    rm -r /tmp/neo-cli && \
     rm /opt/neo-cli.zip
 
 ENV MODULES="RpcServer"
 # RocksDBStore SimplePolicy ApplicationLogs"
-ENV URL="https://github.com/neo-project/neo-modules/releases/download/v${VERSION}-00"
+ENV URL="https://github.com/neo-project/neo-modules/releases/download/v${VERSION}"
 
 # Download, add and decompress version-dependant plugin packages. At the end, delete the zip files.
 RUN for mod in ${MODULES}; do \

--- a/.docker/build/Dockerfile.sharp.sources.from_binaries
+++ b/.docker/build/Dockerfile.sharp.sources.from_binaries
@@ -9,7 +9,7 @@ RUN set -x \
 
 # Publish neo-cli from source as a self-contained deployment for linux-64 into /neo-cli folder (all dependant .dlls are included).
 # See https://docs.microsoft.com/ru-ru/dotnet/core/deploying/#publish-self-contained for details.
-ENV CLIBRANCH="f387c0138e650efca0f38ba3d20db4e72baadc92"
+ENV CLIBRANCH="5809bd5998c9ca56b723629742d057433b51a65d"
 RUN wget -O /tmp/neo-cli.zip https://github.com/neo-project/neo-node/archive/${CLIBRANCH}.zip && \
     unzip -q -d /tmp/neo-node/ /tmp/neo-cli.zip && \
     mkdir /build && \
@@ -21,7 +21,7 @@ RUN wget -O /tmp/neo-cli.zip https://github.com/neo-project/neo-node/archive/${C
     rm -rf /build /tmp/neo-cli.zip /tmp/neo-node
 
 # Build neo-modules from source into /Plugins folder (only plugin .dll and plugin config are included, if you need other dependant .dlls, see the next step)
-ENV MODULESBRANCH="8403137813da5ea7f04c8b8d46b24539fa259d6f"
+ENV MODULESBRANCH="78e30fd7d12fdecfca73f491a35ead6a7460d832"
 ENV MODULES="LevelDBStore RocksDBStore RpcServer"
 RUN wget -O /tmp/neo-modules.zip https://github.com/neo-project/neo-modules/archive/${MODULESBRANCH}.zip && \
     unzip -q -d /tmp/neo-modules/ /tmp/neo-modules.zip && \
@@ -51,7 +51,7 @@ RUN wget -O /tmp/neo-vm.zip https://github.com/neo-project/neo-vm/archive/${NEOV
     rm -rf /tmp/neo-vm.zip tmp/neo-vm
 
 # Publish neo from source as a self-contained deployment for linux-64 into /neo folder (all dependant .dlls are included)
-ENV NEOBRANCH="309981cece2f45386f87340860e2227d70a0dd33"
+ENV NEOBRANCH="414dab140025f46898a3afee3a59a4e18b72d2b2"
 RUN wget -O /tmp/neo.zip https://github.com/neo-project/neo/archive/${NEOBRANCH}.zip && \
     unzip -q -d /tmp/neo/ /tmp/neo.zip && \
     mkdir /build && \

--- a/.docker/build/Dockerfile.sharp.sources.from_local_dependencies
+++ b/.docker/build/Dockerfile.sharp.sources.from_local_dependencies
@@ -20,11 +20,11 @@ RUN set -x \
 #           ├── neo-modules
 #           └── neo-vm
 # Use ENV variables to specify branch, version or revision to download.
-ENV CLIBRANCH="f387c0138e650efca0f38ba3d20db4e72baadc92"
-ENV MODULESBRANCH="8403137813da5ea7f04c8b8d46b24539fa259d6f"
+ENV CLIBRANCH="5809bd5998c9ca56b723629742d057433b51a65d"
+ENV MODULESBRANCH="78e30fd7d12fdecfca73f491a35ead6a7460d832"
 ENV MODULES="LevelDBStore RocksDBStore RpcServer"
 ENV NEOVMBRANCH="a14b934f5b5c8779164e3b96b276984b3a57ccd4"
-ENV NEOBRANCH="309981cece2f45386f87340860e2227d70a0dd33"
+ENV NEOBRANCH="414dab140025f46898a3afee3a59a4e18b72d2b2"
 RUN mkdir /neo-project && \
     wget -O /tmp/neo-cli.zip https://github.com/neo-project/neo-node/archive/${CLIBRANCH}.zip && \
     unzip -q -d /neo-project/ /tmp/neo-cli.zip && \


### PR DESCRIPTION
Close #56.

I have tested (2Go+2C#) and (1Go+3C#) setups with GoRPC node and default Transfers transactions, works fine.

Updated both released and sources cases. Needs to be merge after #54 (there's a useful NEO hash adjustment).

Related: https://github.com/nspcc-dev/neo-go/pull/1633