### PR TITLE
go.template: use shorter ping interval and timeout

### DIFF
--- a/.docker/ir/go.protocol.template.yml
+++ b/.docker/ir/go.protocol.template.yml
@@ -51,8 +51,8 @@ ApplicationConfiguration:
   Relay: true
   DialTimeout: 3
   ProtoTickInterval: 2
-  PingInterval: 30
-  PingTimeout: 90
+  PingInterval: 10
+  PingTimeout: 30
   MaxPeers: 10
   AttemptConnPeers: 5
   #@ if data.values.nodes_info[i].node_name == "single":


### PR DESCRIPTION
These are expected to be tuned for particular networks and default values are
set based on 15s block time expectations. These settings are completely
irrelevant for single node, but our default four node setup uses 5s block
time, so I think we can adjust ping time to 10s with timeout of 30s for this
network.

It technically tunes Go node without tuning C# node in the same way, but
unfortunately C# just doesn't have appropriate settings.