### PR TITLE
.docker: add network delay

### DIFF
--- a/.docker/build/Dockerfile.golang
+++ b/.docker/build/Dockerfile.golang
@@ -29,6 +29,8 @@ RUN set -x \
 # Executable layer
 FROM alpine
 
+RUN apk add --no-cache iproute2-tc
+
 WORKDIR /neo-go
 
 WORKDIR /

--- a/.docker/build/Dockerfile.sharp
+++ b/.docker/build/Dockerfile.sharp
@@ -36,6 +36,7 @@ RUN set -x \
         libunwind8 \
         librocksdb-dev \
         libc6-dev \
+        iproute2 \
     # APT cleanup to reduce image size
     && rm -rf /var/lib/apt/lists/*
 

--- a/.docker/build/Dockerfile.sharp.sources.from_binaries
+++ b/.docker/build/Dockerfile.sharp.sources.from_binaries
@@ -81,6 +81,7 @@ RUN set -x \
         libunwind8 \
         librocksdb-dev \
         libc6-dev \
+        iproute2 \
     # APT cleanup to reduce image size
     && rm -rf /var/lib/apt/lists/*
 

--- a/.docker/build/Dockerfile.sharp.sources.from_local_dependencies
+++ b/.docker/build/Dockerfile.sharp.sources.from_local_dependencies
@@ -85,6 +85,7 @@ RUN set -x \
         libunwind8 \
         librocksdb-dev \
         libc6-dev \
+        iproute2 \
     # APT cleanup to reduce image size
     && rm -rf /var/lib/apt/lists/*
 

--- a/.docker/build/go.entrypoint.sh
+++ b/.docker/build/go.entrypoint.sh
@@ -6,6 +6,16 @@ if [ -z "$ACC" ]; then
   ACC=single.acc
 fi
 
+if [ -n "$NEOBENCH_TC" ]; then
+  # shellcheck disable=SC2086 # Intended splitting of $NEOBENCH_TC (may be "100ms 10ms distribution normal")
+  if tc qdisc add dev eth0 root netem $NEOBENCH_TC; then
+    echo "Set qdisc to netem $NEOBENCH_TC"
+  else
+    echo "Can't set qdisc to netem $NEOBENCH_TC"
+    exit 1
+  fi
+fi
+
 case $@ in
 	"node"*)
 	echo "=> Try to restore blocks before running node"

--- a/.docker/build/sharp.entrypoint.sh
+++ b/.docker/build/sharp.entrypoint.sh
@@ -12,4 +12,15 @@ if test -f /"$ACC"; then
   cp /${ACC} /neo-cli/chain.acc
 fi
 
+
+if [ -n "$NEOBENCH_TC" ]; then
+  # shellcheck disable=SC2086 # Intended splitting of $NEOBENCH_TC (may be "100ms 10ms distribution normal")
+  if tc qdisc add dev eth0 root netem $NEOBENCH_TC; then
+    echo "Set qdisc to netem $NEOBENCH_TC"
+  else
+    echo "Can't set qdisc to netem $NEOBENCH_TC"
+    exit 1
+  fi
+fi
+
 ${BIN} "$@"

--- a/.docker/ir/docker-compose.go.yml
+++ b/.docker/ir/docker-compose.go.yml
@@ -16,6 +16,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-go:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s
@@ -24,6 +26,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
     volumes:
       - ./wallet.one.json:/config/wallet.json
       - ./go.protocol.privnet.one.yml:/config/protocol.privnet.yml
@@ -35,6 +38,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-go:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s
@@ -43,6 +48,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
     volumes:
       - ./wallet.two.json:/config/wallet.json
       - ./go.protocol.privnet.two.yml:/config/protocol.privnet.yml
@@ -54,6 +60,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-go:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s
@@ -62,6 +70,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
     volumes:
       - ./wallet.three.json:/config/wallet.json
       - ./go.protocol.privnet.three.yml:/config/protocol.privnet.yml
@@ -73,6 +82,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-go:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s
@@ -81,6 +92,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
     volumes:
       - ./wallet.four.json:/config/wallet.json
       - ./go.protocol.privnet.four.yml:/config/protocol.privnet.yml

--- a/.docker/ir/docker-compose.mixed.yml
+++ b/.docker/ir/docker-compose.mixed.yml
@@ -15,6 +15,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     container_name: neo-cli-node-one
     stdin_open: true
     tty: true
@@ -28,6 +30,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
 
   node_two:
     labels:
@@ -35,6 +38,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     container_name: neo-cli-node-two
     stdin_open: true
     tty: true
@@ -48,6 +53,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
 
   node_three:
     labels:
@@ -56,6 +62,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-go:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s
@@ -64,6 +72,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
     volumes:
       - ./wallet.three.json:/config/wallet.json
       - ./go.protocol.privnet.three.yml:/config/protocol.privnet.yml
@@ -75,6 +84,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-go:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     command: "node --config-path /config --privnet"
     healthcheck:
       interval: 5s
@@ -83,6 +94,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
     volumes:
       - ./wallet.four.json:/config/wallet.json
       - ./go.protocol.privnet.four.yml:/config/protocol.privnet.yml

--- a/.docker/ir/docker-compose.sharp.yml
+++ b/.docker/ir/docker-compose.sharp.yml
@@ -15,6 +15,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     container_name: neo-cli-node-one
     stdin_open: true
     tty: true
@@ -28,6 +30,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
 
   node_two:
     labels:
@@ -35,6 +38,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     container_name: neo-cli-node-two
     stdin_open: true
     tty: true
@@ -48,6 +53,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
 
   node_three:
     labels:
@@ -55,6 +61,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     container_name: neo-cli-node-three
     stdin_open: true
     tty: true
@@ -68,6 +76,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
 
   node_four:
     labels:
@@ -75,6 +84,8 @@ services:
     image: registry.nspcc.ru/neo-bench/neo-sharp:bench
     logging:
       driver: $NEOBENCH_LOGGER
+    cap_add:
+      - NET_ADMIN
     container_name: neo-cli-node-four
     stdin_open: true
     tty: true
@@ -88,6 +99,7 @@ services:
       timeout: 10s
     environment:
       - ACC=dump.acc
+      - NEOBENCH_TC=$NEOBENCH_TC
 
   healthy:
     image: alpine

--- a/.docker/rpc/docker-compose.go.yml
+++ b/.docker/rpc/docker-compose.go.yml
@@ -18,6 +18,7 @@ services:
       test: ['CMD', 'sh', '-c', 'echo | nc localhost 20331']
     environment:
       - ACC=/dump.acc
+      - NEOBENCH_TC=
     volumes:
       - ../rpc/go.protocol.yml:/config/protocol.privnet.yml
 

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ To add one more node configuration, provide all necessary information to the `no
 Name|Description|Default|Example
 ---|---|---|---
 NEOBENCH_LOGGER|Container logging facility|`none`|`none`, `journald`, `syslog`
+NEOBENCH_TC|Parameters passed to the `tc qdisc` (netem discipline) on container startup| |`delay 100ms`
 
 ## Benchmark results visualisation
 

--- a/runner.sh
+++ b/runner.sh
@@ -38,6 +38,8 @@ echo "   -t                               Request timeout."
 echo "                                    Used for RPC requests."
 echo "                                    Example: -t 30s"
 echo "   -l, --log                        Enable logging on consensus nodes."
+echo "       --tc                         Arguments to pass to 'tc qdisc netem' inside the container."
+echo "                                    Example: 'delay 100ms'"
 exit 0
 }
 
@@ -132,6 +134,12 @@ while test $# -gt 0; do
     -t)
       test $# -gt 0 || fatal "request timeout should be specified"
       ARGS+=( -t "$1")
+      shift
+      ;;
+
+    --tc)
+      test $# -gt 0 || fatal "tc arguments should be specified"
+      export NEOBENCH_TC="$1"
       shift
       ;;
 


### PR DESCRIPTION
Delaying is done inside the container via `tc` command.
It can be enabled via environment $DELAY variable:
`DELAY=1000ms make start.GoFourNodes10wrk`

For this to work container needs CAP_NET_ADMIN capability.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>