### PR TITLE
Expose RPC ports for consensus nodes

### DIFF
--- a/.docker/ir/docker-compose.go.yml
+++ b/.docker/ir/docker-compose.go.yml
@@ -17,6 +17,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     command: "node --config-path /config --privnet"
+    expose: [ "30333" ]
     healthcheck:
       interval: 5s
       retries: 15
@@ -36,6 +37,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     command: "node --config-path /config --privnet"
+    expose: [ "30334" ]
     healthcheck:
       interval: 5s
       retries: 15
@@ -55,6 +57,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     command: "node --config-path /config --privnet"
+    expose: [ "30335" ]
     healthcheck:
       interval: 5s
       retries: 15
@@ -74,6 +77,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     command: "node --config-path /config --privnet"
+    expose: [ "30336" ]
     healthcheck:
       interval: 5s
       retries: 15

--- a/.docker/ir/docker-compose.mixed.yml
+++ b/.docker/ir/docker-compose.mixed.yml
@@ -16,6 +16,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     container_name: neo-cli-node-one
+    expose: [ "20331" ]
     stdin_open: true
     tty: true
     volumes:
@@ -36,6 +37,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     container_name: neo-cli-node-two
+    expose: [ "20331" ]
     stdin_open: true
     tty: true
     volumes:
@@ -57,6 +59,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     command: "node --config-path /config --privnet"
+    expose: [ "30335" ]
     healthcheck:
       interval: 5s
       retries: 15
@@ -76,6 +79,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     command: "node --config-path /config --privnet"
+    expose: [ "30336" ]
     healthcheck:
       interval: 5s
       retries: 15

--- a/.docker/ir/docker-compose.sharp.yml
+++ b/.docker/ir/docker-compose.sharp.yml
@@ -16,6 +16,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     container_name: neo-cli-node-one
+    expose: [ "20331" ]
     stdin_open: true
     tty: true
     volumes:
@@ -36,6 +37,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     container_name: neo-cli-node-two
+    expose: [ "20331" ]
     stdin_open: true
     tty: true
     volumes:
@@ -56,6 +58,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     container_name: neo-cli-node-three
+    expose: [ "20331" ]
     stdin_open: true
     tty: true
     volumes:
@@ -76,6 +79,7 @@ services:
     logging:
       driver: $NEOBENCH_LOGGER
     container_name: neo-cli-node-four
+    expose: [ "20331" ]
     stdin_open: true
     tty: true
     volumes:


### PR DESCRIPTION
This allows us to easily test scenarios where transactions are pushed directly on consensus nodes. Refs https://github.com/nspcc-dev/neo-go/issues/591 .

This is another case worth considering and without rate limiting it leads to something like this on my machine:
```
>./runner.sh -w 100 -m wrk -l -z 10m -a neo_go_node_one:30333 -a neo_go_node_two:30334 -a neo_go_node_three:30335 -a neo_go_node_four:30336 -i /dump.txs
...
2021/08/28 13:34:16 empty block: 7
2021/08/28 13:34:19 CPU: 38.928%, Mem: 169.590MB
2021/08/28 13:34:29 CPU: 96.278%, Mem: 394.059MB
2021/08/28 13:34:31 #8: 8267 transactions in 5056 ms - 1635.087025 tps
2021/08/28 13:34:38 CPU: 80.635%, Mem: 639.059MB
2021/08/28 13:34:46 CPU: 46.457%, Mem: 733.578MB
2021/08/28 13:34:54 CPU: 20.099%, Mem: 667.672MB
2021/08/28 13:35:02 CPU: 21.590%, Mem: 632.375MB
2021/08/28 13:35:12 CPU: 27.505%, Mem: 682.852MB
2021/08/28 13:35:21 CPU: 22.742%, Mem: 668.559MB
2021/08/28 13:35:31 CPU: 22.112%, Mem: 657.395MB
2021/08/28 13:35:40 CPU: 23.573%, Mem: 660.488MB
2021/08/28 13:35:49 CPU: 22.214%, Mem: 657.539MB
2021/08/28 13:35:53 #9: 32073 transactions in 92482 ms - 346.802621 tps
```