### PR TITLE
config: add `--msPerBlock` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ BUILD_DIR=.docker/build
 NEOBENCH_TYPE ?= NEO
 NEOBENCH_FROM_COUNT ?= 1
 NEOBENCH_TO_COUNT ?= 1
+MS_PER_BLOCK ?= 0
 
 .PHONY: help
 
@@ -112,7 +113,7 @@ config:
 	@echo "=> Generate configurations for single-node and four-nodes networks from templates"
 	@set -x \
 		&& cd ./cmd \
-		&& go run ./config/ --go-template go.protocol.template.yml --go-db leveldb --sharp-template sharp.protocol.template.yml --sharp-db LevelDBStore
+		&& go run ./config/ --go-template go.protocol.template.yml --go-db leveldb --sharp-template sharp.protocol.template.yml --sharp-db LevelDBStore --msPerBlock $(MS_PER_BLOCK)
 
 
 # Generate transactions, dump and nodes configurations for four-nodes network

--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ The following default configurations are available:
                                     Example: -l journald -l syslog -l json-file
        --tc                         Arguments to pass to 'tc qdisc netem' inside the container.
                                     Example: 'delay 100ms'
+       --msPerBlock                 Protocol setting specifying the minimal (and targeted for) time interval between blocks. Must be an integer number of milliseconds.
+                                    The default value is set in configuration templates and is 1s and 5s for single node and multinode setup respectively.
+                                    Example: --msPerBlock 3000
 
 ```
 

--- a/cmd/config/main.go
+++ b/cmd/config/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/k14s/ytt/pkg/cmd/template"
 	"github.com/nspcc-dev/neo-go/pkg/config"
@@ -29,6 +30,7 @@ var (
 	goDB              = flag.String("go-db", "leveldb", "database for Go node")
 	sharpTemplateFile = flag.String("sharp-template", "", "configuration template file for C# node")
 	sharpDB           = flag.String("sharp-db", "LevelDBStore", "database for C# node")
+	msPerBlock        = flag.Int("msPerBlock", 0, "time per block in milliseconds")
 )
 
 func main() {
@@ -115,6 +117,9 @@ func generateGoConfig(templatePath, database, suffix string) error {
 			return fmt.Errorf("unable to decode node template #%d: %w", i, err)
 		}
 		template.ApplicationConfiguration.DBConfiguration.Type = database
+		if msPerBlock != nil && *msPerBlock > 0 {
+			template.ProtocolConfiguration.TimePerBlock = time.Duration(*msPerBlock) * time.Millisecond
+		}
 		var configFile string
 		nodeName, err := nodeNameFromSeedList(template.ApplicationConfiguration.P2P.Addresses, template.ProtocolConfiguration.SeedList)
 		if err != nil {
@@ -154,6 +159,9 @@ func generateSharpConfig(templatePath, storageEngine, suffix string) error {
 			return fmt.Errorf("unable to decode node template #%d: %w", i, err)
 		}
 		template.ApplicationConfiguration.Storage.Engine = storageEngine
+		if msPerBlock != nil && *msPerBlock > 0 {
+			template.ProtocolConfiguration.MillisecondsPerBlock = *msPerBlock
+		}
 		var configFile string
 		nodeName, err := nodeNameFromSeedList([]string{":" + strconv.Itoa(int(template.ApplicationConfiguration.P2P.Port))}, template.ProtocolConfiguration.SeedList)
 		if err != nil {

--- a/runner.sh
+++ b/runner.sh
@@ -51,6 +51,9 @@ show_help() {
 	echo "                                    Example: -l journald -l syslog -l json-file"
 	echo "       --tc                         Arguments to pass to 'tc qdisc netem' inside the container."
 	echo "                                    Example: 'delay 100ms'"
+	echo "       --msPerBlock                 Protocol setting specifying the minimal (and targeted for) time interval between blocks. Must be an integer number of milliseconds."
+	echo "                                    The default value is set in configuration templates and is 1s and 5s for single node and multinode setup respectively."
+	echo "                                    Example: --msPerBlock 1000"
 	exit 0
 }
 
@@ -185,6 +188,12 @@ while test $# -gt 0; do
 	--tc)
 		test $# -gt 0 || fatal "tc arguments should be specified"
 		export NEOBENCH_TC="$1"
+		shift
+		;;
+
+	--msPerBlock)
+		test $# -gt 0 || fatal "milliseconds per block should be specified"
+		export MS_PER_BLOCK="$1"
 		shift
 		;;
 


### PR DESCRIPTION
`./runner.sh --nodes mixed --rpc sharp -d "Mytest" -m rate -q 50 -z 5m -t 30s --time $(TIME_PER_BLOCK)`

example:
```
TARGETS := start.GoFourNodes10wrk start.GoFourNodes30wrk start.GoFourNodes100wrk
TIME_BLOCKS := 5000 1000 500 200 100

run-block-tests:
	@$(foreach target,$(TARGETS), \
		$(foreach time,$(TIME_BLOCKS), \
			echo "Running $(target) with time per block $(time) ms" && \
			$(MAKE) $(target) TIME_PER_BLOCK=$(time); \
		) \
	)
```