### PR TITLE
internal: adjust awaiting timeout for setup transactions

### DIFF
--- a/cmd/internal/prepare.go
+++ b/cmd/internal/prepare.go
@@ -158,12 +158,18 @@ func newNEP5Transfer(validatorCount int, sc util.Uint160, from, to util.Uint160,
 }
 
 func fillChain(ctx context.Context, c *rpcclient.Client, proto result.Protocol, sgn *signer, vote bool, opts BenchOptions) error {
+	// minAwaitThreshold is the minimum required threshold for setup transactions to be awaited.
+	var minAwaitThreshold = 3 * time.Second
+
 	cs, err := c.GetNativeContracts()
 	if err != nil {
 		return err
 	}
 
 	timeout := 3 * time.Duration(proto.MillisecondsPerBlock) * time.Millisecond
+	if timeout < minAwaitThreshold {
+		timeout = minAwaitThreshold
+	}
 
 	var neoHash, gasHash, mgmtHash util.Uint160
 	for i := range cs {


### PR DESCRIPTION
Fix the following error on short-blocks setup:
```
2024-04-23 12:54:47 2024/04/23 10:54:47 Used [go-node:20331] rpc addresses
2024-04-23 12:54:47 2024/04/23 10:54:47 Run benchmark for Go4x1_Block_100 :: NEO-GO
2024-04-23 12:54:57 2024/04/23 10:54:57 Read 3000000 txs from /dump.txs
2024-04-23 12:55:06 2024/04/23 10:55:06 CPU: 4.959%, Mem: 243.746MB
2024-04-23 12:55:13 2024/04/23 10:55:13 Done 16.094694633s
2024-04-23 12:55:13 2024/04/23 10:55:13 Init 10 workers / 5m0s time limit (3000000 txs will try to send)
2024-04-23 12:55:13 2024/04/23 10:55:13 Prepare chain for benchmark
2024-04-23 12:55:13 2024/04/23 10:55:13 Determined validators count: 4
2024-04-23 12:55:13 2024/04/23 10:55:13 Sending NEO and GAS transfer tx
2024-04-23 12:55:13 2024/04/23 10:55:13 could not create blocks: timeout while waiting for prepare tx to persist
```