### PR TITLE
cmd: fix mempool OOM error detection for NeoGo node

### DIFF
--- a/.docker/build/Dockerfile.golang
+++ b/.docker/build/Dockerfile.golang
@@ -6,7 +6,7 @@ WORKDIR /neo-go
 # Install deps:
 RUN apk add --no-cache git
 
-ARG REV="v0.104.0"
+ARG REV="v0.105.1"
 ARG REPO="github.com/nspcc-dev/neo-go"
 
 # Clone and build repo:

--- a/cmd/internal/client.go
+++ b/cmd/internal/client.go
@@ -129,7 +129,7 @@ func (c *RPCClient) SendTX(ctx context.Context, tx string) error {
 
 	if err := c.doRPCCall(ctx, rpc, &res, c.txSender); err != nil {
 		msg := err.Error()
-		if strings.Contains(msg, "The memory pool is full and no more transactions can be sent.") || strings.Contains(msg, "OutOfMemory") {
+		if errors.Is(err, neorpc.ErrMempoolCapReached) || strings.Contains(msg, "OutOfMemory") {
 			return ErrMempoolOOM
 		}
 		return err


### PR DESCRIPTION
Otherwise we have a tremendous number of RPC errors in our logs and small number of blocks since no retries happen:
```
Go7x1 :: NEO-GO_0.105.1 / 100 wrk / 5m0s

TXs ≈ 650000
RPS ≈ 9236.825
RPC Errors  ≈ 2350000 / 78.333%
TPS ≈ 9295.009
DefaultMSPerBlock = 5000

CPU ≈ NaN%
Mem ≈ NaNMB

MillisecondsFromStart, CPU, Mem

DeltaTime, TransactionsCount, TPS
5102, 50000, 9800.078
5454, 50000, 9167.583
5435, 50000, 9199.632
5368, 50000, 9314.456
5367, 50000, 9316.192
5384, 50000, 9286.776
5408, 50000, 9245.562
5418, 50000, 9228.498
5408, 50000, 9245.562
5451, 50000, 9172.629
5376, 50000, 9300.595
5378, 50000, 9297.136
5381, 50000, 9291.953
```