### PR TITLE
build: migrate to AS keyword usage in Dockerfiles

### DIFF
--- a/.docker/build/Dockerfile.bench
+++ b/.docker/build/Dockerfile.bench
@@ -1,5 +1,5 @@
 # Builder layer
-FROM golang:1.23-alpine as builder
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /bench
 

--- a/.docker/build/Dockerfile.golang
+++ b/.docker/build/Dockerfile.golang
@@ -1,5 +1,5 @@
 # Builder layer
-FROM golang:1.23-alpine as builder
+FROM golang:1.23-alpine AS builder
 
 WORKDIR /neo-go
 

--- a/.docker/build/Dockerfile.sharp
+++ b/.docker/build/Dockerfile.sharp
@@ -9,7 +9,7 @@ RUN set -x \
     # APT cleanup to reduce image size
     && rm -rf /var/lib/apt/lists/*
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 as Final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS Final
 
 # arguments to choose version of neo-cli to install
 ARG VERSION="3.7.4"


### PR DESCRIPTION
Fix the following Docker image build warning that stops the build:
```
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
```