### PR TITLE
.docker: bump NeoGo image version to 0.108.0

### DIFF
--- a/.docker/build/Dockerfile.golang
+++ b/.docker/build/Dockerfile.golang
@@ -6,7 +6,7 @@ WORKDIR /neo-go
 # Install deps:
 RUN apk add --no-cache git
 
-ARG REV="v0.106.0"
+ARG REV="v0.108.1"
 ARG REPO="github.com/nspcc-dev/neo-go"
 
 # Clone and build repo:


### PR DESCRIPTION
Should be a part of 7538ebb4e9ae24c9ef065cf0817b3c5507a89a8b, otherwise old NeoGo version fails to read config generated by new NeoGo version:
```
failed to unmarshal config YAML: yaml: unmarshal errors:
  line 18: field NeoFSStateSyncExtensions not found in type config.ProtocolConfiguration
  line 40: field RemoveUntraceableHeaders not found in type config.ApplicationConfiguration
  line 43: field SaveInvocations not found in type config.ApplicationConfiguration
  line 129: field NeoFSBlockFetcher not found in type config.ApplicationConfiguration
```