### PR TITLE
.docker: properly build C# node plugins

### DIFF
--- a/.docker/build/Dockerfile.sharp.sources
+++ b/.docker/build/Dockerfile.sharp.sources
@@ -55,7 +55,10 @@ RUN mkdir /Plugins && \
         dotnet restore /neo-project/neo-node/plugins/${mod}/; \
         dotnet build -c Release /neo-project/neo-node/plugins/${mod}/; \
 	    mkdir /Plugins/${mod}; \
-        cp -r /neo-project/neo-node/plugins/${mod}/bin/Release/net10.0/* /Plugins/${mod}; \
+        cp /neo-project/neo-node/plugins/${mod}/bin/Release/net10.0/${mod}.dll /Plugins/${mod}; \
+        if [ ${mod} == "StateService" ]; then \
+            cp /neo-project/neo-node/plugins/${mod}/bin/Release/net10.0/MPTTrie.dll /Plugins/${mod}; \
+        fi; \
     done
 
 # All things are published, so build the final image by copying binaries from build.


### PR DESCRIPTION
Do not include dependant plugin DLLs to the resulting node build, otherwise RpcServer plugin double-start happens.